### PR TITLE
snapper-gui should try to mount the snapshot

### DIFF
--- a/snappergui/glade/mainWindow.glade
+++ b/snappergui/glade/mainWindow.glade
@@ -89,6 +89,7 @@ for filesystem snapshot management</property>
     <property name="height_request">600</property>
     <property name="can_focus">False</property>
     <property name="icon_name">drive-harddisk</property>
+    <signal name="destroy" handler="on_main_destroy" swapped="no"/>
     <child>
       <object class="GtkBox" id="snapshotsBox">
         <property name="visible">True</property>

--- a/snappergui/mainWindow.py
+++ b/snappergui/mainWindow.py
@@ -9,7 +9,6 @@ from gi.repository import Gtk
 from time import strftime, localtime
 from pwd import getpwuid
 
-
 class SnapperGUI():
     """docstring for SnapperGUI"""
 
@@ -136,6 +135,8 @@ class SnapperGUI():
         for path in paths:
             treeiter = model.get_iter(path)
             mountpoint = snapper.GetMountPoint(config, model[treeiter][0])
+            if model[treeiter][6] != '':
+                snapper.MountSnapshot(config,model[treeiter][0],'true')
             subprocess.Popen(['xdg-open', mountpoint])
             self.statusbar.push(True,
                 "The mount point for the snapshot %s from %s is %s"%
@@ -196,3 +197,10 @@ class SnapperGUI():
 
     def on_dbus_config_deleted(self,args):
         print("Config Deleted")
+
+    def on_main_destroy(self,args):
+        for config in snapper.ListConfigs():
+            for snapshot in snapper.ListSnapshots(config[0]):
+                if snapshot[6] != '':
+                    snapper.UmountSnapshot(config[0],snapshot[0],'true')
+


### PR DESCRIPTION
In case of a lvm snapshot, it has to be mounted beforehand
so call MountSnapshot beforehand.
call UmountSnapshot for all timeline snapshot when closing snapper-gui
too, to avoid leaving open snapshots

For issue #24 