### PR TITLE
Fix whitespaces and typos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,24 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
- 
+
 # from options["setup"] in build.vel
 
 config = {
- 'name': 'snappergui',
- 'version': '0.1',
- 'packages': ['snappergui'],
- 'description': 'snapper-gui grafical user interface for snapper btrfs snapshot manager',
- 'author': 'Ricardo Vieira',
- 'url': 'https://github.com/ricardo-vieira/snapper-gui',
- 'download_url': 'https://github.com/ricardo-vieira/snapper-gui',
- 'author_email': 'ricardo.vieira@ist.utl.pt',
- 'package_data' : {"snappergui": ["glade/*.glade",
- 								"icons/*.svg",
- 								"ui/*.ui"]},
- 'data_files': [ ('share/applications', ['snapper-gui.desktop'])],
- 'entry_points' : { 'gui_scripts' : 
-                    [ 'snapper-gui = snappergui.application:start_ui' ] }
+    'name': 'snappergui',
+    'version': '0.1',
+    'packages': ['snappergui'],
+    'description': 'snapper-gui graphical user interface for snapper btrfs snapshot manager',
+    'author': 'Ricardo Vieira',
+    'url': 'https://github.com/ricardo-vieira/snapper-gui',
+    'download_url': 'https://github.com/ricardo-vieira/snapper-gui',
+    'author_email': 'ricardo.vieira@ist.utl.pt',
+    'package_data': {"snappergui": ["glade/*.glade",
+                                    "icons/*.svg",
+                                    "ui/*.ui"]},
+    'data_files': [('share/applications', ['snapper-gui.desktop'])],
+    'entry_points': {'gui_scripts':
+                         ['snapper-gui = snappergui.application:start_ui']}
 }
 
 setup(**config)

--- a/snapper-gui.desktop
+++ b/snapper-gui.desktop
@@ -7,4 +7,3 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Utilities;
-	

--- a/snappergui/application.py
+++ b/snappergui/application.py
@@ -3,11 +3,13 @@ from gi.repository import Gtk, GLib, GdkPixbuf, Gio
 from snappergui.mainWindow import SnapperGUI
 from snappergui.propertiesDialog import propertiesDialog
 
+
 def start_ui():
     app = Application()
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     exit_status = app.run(sys.argv)
     sys.exit(exit_status)
+
 
 class Application(Gtk.Application):
     def __init__(self):

--- a/snappergui/createConfig.py
+++ b/snappergui/createConfig.py
@@ -2,8 +2,10 @@ from snappergui import snapper
 import pkg_resources
 from gi.repository import Gtk
 
+
 class createConfig(object):
     """docstring for createConfig"""
+
     def __init__(self, parent):
         super(createConfig, self).__init__()
         builder = Gtk.Builder()
@@ -21,20 +23,19 @@ class createConfig(object):
         builder.get_object("fsTypeCombo").set_active(0)
 
     def on_name_changed(self, widget):
-        self.name = widget.get_chars(0,-1)
+        self.name = widget.get_chars(0, -1)
 
     def on_subvolume_changed(self, widget):
-        self.subvolume = widget.get_chars(0,-1)
+        self.subvolume = widget.get_chars(0, -1)
 
     def on_fstype_changed(self, widget):
         self.fstype = widget.get_active_text()
 
     def on_template_changed(self, widget):
-        self.template = widget.get_chars(0,-1)
+        self.template = widget.get_chars(0, -1)
 
     def run(self):
         return self.dialog.run()
 
     def destroy(self):
         self.dialog.destroy()
-

--- a/snappergui/createSnapshot.py
+++ b/snappergui/createSnapshot.py
@@ -2,6 +2,7 @@ from snappergui import snapper
 import pkg_resources
 from gi.repository import Gtk, Gdk
 
+
 class createSnapshot(object):
     TYPE_HERE = "<Type here>"
 
@@ -34,8 +35,6 @@ class createSnapshot(object):
 
         builder.get_object("cleanupcombo").set_active(0)
 
-
-
     def on_config_changed(self,widget):
         self.config = widget.get_model()[widget.get_active()][0]
 
@@ -65,7 +64,6 @@ class createSnapshot(object):
             del userdatamodel[path]
         else:
             userdatamodel[path][0] = new_text
-
 
     def _on_value_edited(self, renderer, path, new_text):
         userdatamodel = self.userdataTree.get_model()

--- a/snappergui/deleteDialog.py
+++ b/snappergui/deleteDialog.py
@@ -6,6 +6,7 @@ from pwd import getpwuid
 
 class deleteDialog(object):
     """docstring for deleteDialog"""
+
     def __init__(self, parent, config, snapshots):
         super(deleteDialog, self).__init__()
         builder = Gtk.Builder()
@@ -21,21 +22,21 @@ class deleteDialog(object):
         self.to_delete = snapshots
 
         parents = []
-        self.deleteTreeStore = Gtk.TreeStore(bool, int, str,  str)
+        self.deleteTreeStore = Gtk.TreeStore(bool, int, str, str)
         for snapshot in snapshots:
-            snapinfo = snapper.GetSnapshot(config,snapshot)
-            #self.deleteTreeStore.append(self.get_row(snapinfo))
-            if (snapinfo[1] == 1): # Pre Snapshot
+            snapinfo = snapper.GetSnapshot(config, snapshot)
+            # self.deleteTreeStore.append(self.get_row(snapinfo))
+            if snapinfo[1] == 1:  # Pre snapshot
                 parents.append(self.deleteTreeStore.append(None, self.get_row(snapinfo)))
-            elif (snapinfo[1] == 2): # Post snappshot
+            elif snapinfo[1] == 2:  # Post snapshot
                 parent_node = None
                 for parent in parents:
-                    if (self.deleteTreeStore.get_value(parent, 1) == snapinfo[2]):
+                    if self.deleteTreeStore.get_value(parent, 1) == snapinfo[2]:
                         parent_node = parent
                         break
-                self.deleteTreeStore.append(parent_node, )
+                self.deleteTreeStore.append(parent_node)
             else:  # Single snapshot
-                self.deleteTreeStore.append(None , self.get_row(snapinfo))
+                self.deleteTreeStore.append(None, self.get_row(snapinfo))
         self.deletetreeview.set_model(self.deleteTreeStore)
         self.deletetreeview.expand_all()
 
@@ -47,13 +48,13 @@ class deleteDialog(object):
         self.dialog.destroy()
         return response
 
-    def on_toggle_delete_snapshot(self,widget,path):
+    def on_toggle_delete_snapshot(self, widget, path):
         treeiter = self.deleteTreeStore.get_iter(path)
         self.deleteTreeStore.set_value(treeiter,
                                        False,
-                                       not(self.deleteTreeStore.get_value(treeiter, False)))
+                                       not (self.deleteTreeStore.get_value(treeiter, False)))
         snapshot_num = self.deleteTreeStore.get_value(treeiter, True)
-        if self.deleteTreeStore.get_value(treeiter,False):
+        if self.deleteTreeStore.get_value(treeiter, False):
             if snapshot_num not in self.to_delete:
                 self.to_delete.append(snapshot_num)
         else:

--- a/snappergui/mainWindow.py
+++ b/snappergui/mainWindow.py
@@ -9,6 +9,7 @@ from gi.repository import Gtk
 from time import strftime, localtime
 from pwd import getpwuid
 
+
 class SnapperGUI():
     """docstring for SnapperGUI"""
 
@@ -38,8 +39,8 @@ class SnapperGUI():
         self.init_dbus_signal_handlers()
         self.window.show()
 
-    def snapshot_columns(self,snapshot):
-        if(snapshot[3] == -1):
+    def snapshot_columns(self, snapshot):
+        if snapshot[3] == -1:
             date = "Now"
         else:
             date = strftime("%a %x %R", localtime(snapshot[3]))
@@ -77,7 +78,7 @@ class SnapperGUI():
                 self.builder.get_object("view-changes").set_sensitive(True)
 
             try:
-                snapshot_data = snapper.GetSnapshot(config,model[model.get_iter(paths[0])][0])
+                snapshot_data = snapper.GetSnapshot(config, model[model.get_iter(paths[0])][0])
                 userdata_liststore = Gtk.ListStore(str, str)
                 for key, value in snapshot_data[7].items():
                     userdata_liststore.append([key, value])
@@ -91,9 +92,9 @@ class SnapperGUI():
         dialog.destroy()
         if response == Gtk.ResponseType.OK:
             newSnapshot = snapper.CreateSingleSnapshot(dialog.config,
-                                        dialog.description,
-                                        dialog.cleanup,
-                                        dialog.userdata)
+                                                       dialog.description,
+                                                       dialog.cleanup,
+                                                       dialog.userdata)
         elif response == Gtk.ResponseType.CANCEL:
             pass
 
@@ -103,9 +104,9 @@ class SnapperGUI():
         dialog.destroy()
         if response == Gtk.ResponseType.OK:
             snapper.CreateConfig(dialog.name,
-                                dialog.subvolume,
-                                dialog.fstype,
-                                dialog.template)
+                                 dialog.subvolume,
+                                 dialog.fstype,
+                                 dialog.template)
         elif response == Gtk.ResponseType.CANCEL:
             pass
 
@@ -123,7 +124,7 @@ class SnapperGUI():
             if model.iter_has_child(treeiter):
                 child_treeiter = model.iter_children(treeiter)
                 snapshots.append(model[child_treeiter][0])
-        dialog = deleteDialog(self.window, config,snapshots)
+        dialog = deleteDialog(self.window, config, snapshots)
         response = dialog.run()
         if response == Gtk.ResponseType.YES and len(dialog.to_delete) > 0:
             snapper.DeleteSnapshots(config, dialog.to_delete)
@@ -136,11 +137,11 @@ class SnapperGUI():
             treeiter = model.get_iter(path)
             mountpoint = snapper.GetMountPoint(config, model[treeiter][0])
             if model[treeiter][6] != '':
-                snapper.MountSnapshot(config,model[treeiter][0],'true')
+                snapper.MountSnapshot(config, model[treeiter][0], 'true')
             subprocess.Popen(['xdg-open', mountpoint])
             self.statusbar.push(True,
-                "The mount point for the snapshot %s from %s is %s"%
-                (model[treeiter][0], config, mountpoint))
+                                "The mount point for the snapshot %s from %s is %s" %
+                                (model[treeiter][0], config, mountpoint))
 
     def on_viewchanges_clicked(self, widget):
         config = self.get_current_config()
@@ -152,36 +153,36 @@ class SnapperGUI():
             end = model[paths[-1]][0]
             window = changesWindow(config, begin, end)
         elif len(paths) == 1 and model.iter_has_child(model.get_iter(paths[0])):
-            # open a changes window with the selected pre snapshot and is's post
+            # open a changes window with the selected pre snapshot and its corresponding post snapshot
             child_iter = model.iter_children(model.get_iter(paths[0]))
             begin = model[paths[0]][0]
-            end = model.get_value(child_iter,0)
+            end = model.get_value(child_iter, 0)
             window = changesWindow(config, begin, end)
 
     def init_dbus_signal_handlers(self):
         signals = {
-        "SnapshotCreated" : self.on_dbus_snapshot_created,
-        "SnapshotModified" : self.on_dbus_snapshot_modified,
-        "SnapshotsDeleted" : self.on_dbus_snapshots_deleted,
-        "ConfigCreated" : self.on_dbus_config_created,
-        "ConfigModified" : self.on_dbus_config_modified,
-        "ConfigDeleted" : self.on_dbus_config_deleted
+            "SnapshotCreated": self.on_dbus_snapshot_created,
+            "SnapshotModified": self.on_dbus_snapshot_modified,
+            "SnapshotsDeleted": self.on_dbus_snapshots_deleted,
+            "ConfigCreated": self.on_dbus_config_created,
+            "ConfigModified": self.on_dbus_config_modified,
+            "ConfigDeleted": self.on_dbus_config_deleted
         }
         for signal, handler in signals.items():
-            snapper.connect_to_signal(signal,handler)
+            snapper.connect_to_signal(signal, handler)
 
-    def on_dbus_snapshot_created(self,config,snapshot):
-        self.statusbar.push(True, "Snapshot %s created for %s"% (str(snapshot), config))
+    def on_dbus_snapshot_created(self, config, snapshot):
+        self.statusbar.push(True, "Snapshot %s created for %s" % (str(snapshot), config))
         self.configView[config].add_snapshot_to_tree(str(snapshot))
 
-    def on_dbus_snapshot_modified(self,config,snapshot):
+    def on_dbus_snapshot_modified(self, config, snapshot):
         print("Snapshot SnapshotModified")
 
-    def on_dbus_snapshots_deleted(self,config,snapshots):
+    def on_dbus_snapshots_deleted(self, config, snapshots):
         snaps_str = ""
         for snapshot in snapshots:
             snaps_str += str(snapshot) + " "
-        self.statusbar.push(True, "Snapshots deleted from %s: %s"% (config, snaps_str))
+        self.statusbar.push(True, "Snapshots deleted from %s: %s" % (config, snaps_str))
         for deleted in snapshots:
             self.configView[config].remove_snapshot_from_tree(deleted)
 
@@ -189,18 +190,16 @@ class SnapperGUI():
         self.configView[config] = snapshotsView(config)
         self.configView[config].update_view()
         self.stack.add_titled(self.configView[config]._TreeView, config, config)
-        self.statusbar.push(5,"Created new configuration %s"% config)
+        self.statusbar.push(5, "Created new configuration %s" % config)
 
-
-    def on_dbus_config_modified(self,args):
+    def on_dbus_config_modified(self, args):
         print("Config Modified")
 
-    def on_dbus_config_deleted(self,args):
+    def on_dbus_config_deleted(self, args):
         print("Config Deleted")
 
-    def on_main_destroy(self,args):
+    def on_main_destroy(self, args):
         for config in snapper.ListConfigs():
             for snapshot in snapper.ListSnapshots(config[0]):
                 if snapshot[6] != '':
-                    snapper.UmountSnapshot(config[0],snapshot[0],'true')
-
+                    snapper.UmountSnapshot(config[0], snapshot[0], 'true')

--- a/snappergui/propertiesDialog.py
+++ b/snappergui/propertiesDialog.py
@@ -2,8 +2,10 @@ from snappergui import snapper
 import pkg_resources, dbus
 from gi.repository import Gtk
 
+
 class PropertiesTab(object):
     """docstring for PropertiesTab"""
+
     def __init__(self, config):
         builder = Gtk.Builder()
         builder.add_from_file(pkg_resources.resource_filename("snappergui",
@@ -29,7 +31,7 @@ class PropertiesTab(object):
                 elif v == "no":
                     widget.set_active(False)
             else:
-                print("ERROR: Could not handle property \"%s\"."% k)
+                print("ERROR: Could not handle property \"%s\"." % k)
             self.widgets[k] = widget
 
     def get_current_value(self, setting):
@@ -37,7 +39,7 @@ class PropertiesTab(object):
         if type(widget) == Gtk.Entry:
             return widget.get_text()
         elif type(widget) == Gtk.Switch:
-            if(widget.get_active()):
+            if widget.get_active():
                 return "yes"
             else:
                 return "no"
@@ -47,6 +49,7 @@ class PropertiesTab(object):
 
 class propertiesDialog(object):
     """docstring for propertiesDialog"""
+
     def __init__(self, widget, parent):
         self.parent = parent
 
@@ -66,7 +69,6 @@ class propertiesDialog(object):
             self.notebook.append_page(currentTab.configsGrid, Gtk.Label.new(config[0]))
         self.notebook.show_all()
 
-
     def get_changed_settings(self, config):
         changed = {}
         for k, v in snapper.GetConfig(config)[2].items():
@@ -81,9 +83,10 @@ class propertiesDialog(object):
             try:
                 snapper.SetConfig(currentConfig, self.get_changed_settings(currentConfig))
             except dbus.exceptions.DBusException as error:
-                if(str(error).find("error.no_permission") != -1):
+                if str(error).find("error.no_permission") != -1:
                     self.dialog.destroy()
                     dialog = Gtk.MessageDialog(self.parent, 0, Gtk.MessageType.WARNING,
-                    Gtk.ButtonsType.OK, "You don't have permission to edit configurations")
+                                               Gtk.ButtonsType.OK,
+                                               "You don't have permission to edit configurations")
                     dialog.run()
                     dialog.destroy()

--- a/snappergui/snapshotsView.py
+++ b/snappergui/snapshotsView.py
@@ -4,8 +4,10 @@ from gi.repository import Gtk
 from time import strftime, localtime
 from pwd import getpwuid
 
+
 class snapshotsView(Gtk.Widget):
     """docstring for snapshotsView"""
+
     def __init__(self, config):
         super(snapshotsView, self).__init__()
         self.config = config
@@ -24,8 +26,8 @@ class snapshotsView(Gtk.Widget):
         if treestore:
             self._TreeView.set_model(treestore)
 
-    def snapshot_columns(self,snapshot):
-        if(snapshot[3] == -1):
+    def snapshot_columns(self, snapshot):
+        if snapshot[3] == -1:
             date = "Now"
         else:
             date = strftime("%a %x %R", localtime(snapshot[3]))
@@ -47,17 +49,17 @@ class snapshotsView(Gtk.Widget):
         parents = []
         self.count = len(snapshots_list)
         for snapshot in snapshots_list:
-            if (snapshot[1] == 1): # Pre Snapshot
-                parents.append(configstree.append(None , self.snapshot_columns(snapshot)))
-            elif (snapshot[1] == 2): # Post snappshot
+            if snapshot[1] == 1:  # Pre snapshot
+                parents.append(configstree.append(None, self.snapshot_columns(snapshot)))
+            elif snapshot[1] == 2:  # Post snapshot
                 parent_node = None
                 for parent in parents:
-                    if (configstree.get_value(parent, 0) == snapshot[2]):
+                    if configstree.get_value(parent, 0) == snapshot[2]:
                         parent_node = parent
                         break
-                configstree.append(parent_node , self.snapshot_columns(snapshot))
+                configstree.append(parent_node, self.snapshot_columns(snapshot))
             else:  # Single snapshot
-                configstree.append(None , self.snapshot_columns(snapshot))
+                configstree.append(None, self.snapshot_columns(snapshot))
         return configstree
 
     def add_snapshot_to_tree(self, snapshot, pre_snapshot=None):
@@ -68,9 +70,9 @@ class snapshotsView(Gtk.Widget):
         except dbus.exceptions.DBusException:
             return
         pre_number = snapinfo[2]
-        if (snapinfo[1] == 2): # if type is post
+        if snapinfo[1] == 2:  # if type is post
             for aux, row in enumerate(treemodel):
-                if(pre_number == row[0]):
+                if pre_number == row[0]:
                     pre_snapshot = treemodel.get_iter(aux)
                     break
         treemodel.append(pre_snapshot, self.snapshot_columns(snapinfo))
@@ -78,9 +80,9 @@ class snapshotsView(Gtk.Widget):
     def remove_snapshot_from_tree(self, snapshot):
         treemodel = self._TreeView.get_model()
         for aux, row in enumerate(treemodel):
-            if(snapshot == row[0]):
+            if snapshot == row[0]:
                 has_child = treemodel.iter_has_child(treemodel.get_iter(aux))
-                if(has_child):
+                if has_child:
                     # FIXME meh
                     self.update_view()
                 else:
@@ -89,14 +91,13 @@ class snapshotsView(Gtk.Widget):
     def on_description_edited(self, widget, treepath, text):
         snapshot_row = self._TreeView.get_model()[treepath]
         snapshot_num = snapshot_row[0]
-        snapshot_info = snapper.GetSnapshot(self.config,snapshot_num)
-        snapper.SetSnapshot(self.config,snapshot_info[0],text,snapshot_info[6],snapshot_info[7])
+        snapshot_info = snapper.GetSnapshot(self.config, snapshot_num)
+        snapper.SetSnapshot(self.config, snapshot_info[0], text, snapshot_info[6], snapshot_info[7])
         snapshot_row[5] = text
-
 
     def on_cleanup_edited(self, widget, treepath, text):
         snapshot_row = self._TreeView.get_model()[treepath]
         snapshot_num = snapshot_row[0]
-        snapshot_info = snapper.GetSnapshot(self.config,snapshot_num)
-        snapper.SetSnapshot(self.config,snapshot_info[0],snapshot_info[5],text,snapshot_info[7])
+        snapshot_info = snapper.GetSnapshot(self.config, snapshot_num)
+        snapper.SetSnapshot(self.config, snapshot_info[0], snapshot_info[5], text, snapshot_info[7])
         snapshot_row[6] = text


### PR DESCRIPTION
* setup.py (config): This file contained a salad from tabs and spaces.
  I wonder how that even worked -- AFAIK Python 3 blows up with syntax
  error on mixed indents.

  (description): Fix typos in word "graphical".

* snapper-gui.desktop: Remove trailing whitespace.

* snappergui/*.py:

  Conformance to PEP8:
  - Remove redundant parentheses around `if` conditions.
  - Fix whitespaces between classes and methods.
  - Fix whitespaces around start of comments: 2+1 (__#_).
  - Other whitespace and indentation fixes.

  (changesWindow::get_treestore_from_tree::get_childs):
  - Rename inner local function to get_children().
  - Rename argument `tree` to `subtree` to prevent variable shadowing.

  (changesWindow::_on_pathstree_selection_changed): Never compare to
  None though equality (==, !=); only through `is` and `is not`
  operators.

* changesWindow.py (StatusFlags): Align to the right and disable
  PyCharm formatter via comments.