### PR TITLE
fix Categories to let KDE recognizes it properly.

### DIFF
--- a/snapper-gui.desktop
+++ b/snapper-gui.desktop
@@ -6,4 +6,4 @@ Icon=drive-harddisk
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Utilities;
+Categories=Utilities;Utility;

--- a/snapper-gui.desktop
+++ b/snapper-gui.desktop
@@ -6,4 +6,4 @@ Icon=drive-harddisk
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Utilities;Utility;
+Categories=Utilities;System;


### PR DESCRIPTION
This app in KDE Launcher is assigned at `Unknown` because `Utilities` category is unknown to KDE, this commit fixes this problem and KDE now assigns its icon at correct place.