### PR TITLE
Update mainWindow.glade

### DIFF
--- a/snappergui/glade/mainWindow.glade
+++ b/snappergui/glade/mainWindow.glade
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAboutDialog" id="aboutdialog1">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="type_hint">dialog</property>
-    <property name="program_name">SnapperGUI</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="type-hint">dialog</property>
+    <property name="program-name">SnapperGUI</property>
     <property name="version">0.03</property>
     <property name="copyright" translatable="yes">2013</property>
     <property name="comments" translatable="yes">A user interface for the program snapper
 for filesystem snapshot management</property>
-    <property name="logo_icon_name">image-missing</property>
-    <property name="license_type">gpl-2-0</property>
+    <property name="logo-icon-name">image-missing</property>
+    <property name="license-type">gpl-2-0</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="aboutdialog-vbox1">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="aboutdialog-action_area1">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -39,13 +39,13 @@ for filesystem snapshot management</property>
   <object class="GtkActionGroup" id="configsGroup"/>
   <object class="GtkAccelGroup" id="configsaccelgroup"/>
   <object class="GtkActionGroup" id="configActions">
-    <property name="accel_group">configsaccelgroup</property>
+    <property name="accel-group">configsaccelgroup</property>
     <child>
       <object class="GtkAction" id="create-snapshot">
         <property name="label" translatable="yes">Create Snapshot</property>
-        <property name="short_label" translatable="yes">New</property>
+        <property name="short-label" translatable="yes">New</property>
         <property name="tooltip" translatable="yes">Create a new snapshot for the current configuration</property>
-        <property name="stock_id">gtk-add</property>
+        <property name="stock-id">gtk-add</property>
         <signal name="activate" handler="on_create_snapshot" swapped="no"/>
       </object>
       <accelerator key="n" modifiers="GDK_CONTROL_MASK"/>
@@ -53,13 +53,13 @@ for filesystem snapshot management</property>
   </object>
   <object class="GtkAccelGroup" id="snapsaccelgroup"/>
   <object class="GtkActionGroup" id="snapshotActions">
-    <property name="accel_group">snapsaccelgroup</property>
+    <property name="accel-group">snapsaccelgroup</property>
     <child>
       <object class="GtkAction" id="delete-snapshot">
         <property name="label" translatable="yes">Delete</property>
-        <property name="short_label" translatable="yes">Del</property>
+        <property name="short-label" translatable="yes">Del</property>
         <property name="tooltip" translatable="yes">Delete selected snapshots</property>
-        <property name="stock_id">gtk-remove</property>
+        <property name="stock-id">gtk-remove</property>
         <signal name="activate" handler="on_delete_snapshot" object="treeview-selection1" swapped="no"/>
       </object>
       <accelerator key="Delete"/>
@@ -67,9 +67,9 @@ for filesystem snapshot management</property>
     <child>
       <object class="GtkAction" id="open-mountpoint">
         <property name="label" translatable="yes">Open</property>
-        <property name="short_label" translatable="yes">Open</property>
+        <property name="short-label" translatable="yes">Open</property>
         <property name="tooltip" translatable="yes">Open snapshot mountpoint</property>
-        <property name="stock_id">gtk-open</property>
+        <property name="stock-id">gtk-open</property>
         <signal name="activate" handler="on_open_snapshot_folder" object="treeview-selection1" swapped="no"/>
       </object>
       <accelerator key="o" modifiers="GDK_CONTROL_MASK"/>
@@ -77,54 +77,54 @@ for filesystem snapshot management</property>
     <child>
       <object class="GtkAction" id="view-changes">
         <property name="label" translatable="yes">View changes</property>
-        <property name="short_label" translatable="yes">Changes</property>
+        <property name="short-label" translatable="yes">Changes</property>
         <property name="tooltip" translatable="yes">Show which files have changed between selected snapshots</property>
-        <property name="stock_id">gtk-file</property>
+        <property name="stock-id">gtk-file</property>
         <signal name="activate" handler="on_viewchanges_clicked" object="treeview-selection1" swapped="no"/>
       </object>
     </child>
   </object>
   <object class="GtkApplicationWindow" id="applicationwindow1">
-    <property name="width_request">700</property>
-    <property name="height_request">600</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">drive-harddisk</property>
+    <property name="width-request">700</property>
+    <property name="height-request">600</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">drive-harddisk</property>
     <signal name="destroy" handler="on_main_destroy" swapped="no"/>
     <child>
       <object class="GtkBox" id="snapshotsBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkToolbar" id="toolbar1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="toolbar_style">both</property>
+            <property name="can-focus">False</property>
+            <property name="toolbar-style">both</property>
             <child>
               <object class="GtkMenuToolButton" id="toolbutton1">
-                <property name="related_action">create-snapshot</property>
+                <property name="related-action">create-snapshot</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Create a new snapshot</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-add</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Create a new snapshot</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-add</property>
                 <child type="menu">
                   <object class="GtkMenu" id="menu6">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="menuitem14">
-                        <property name="related_action">create-snapshot</property>
+                        <property name="related-action">create-snapshot</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Create Snapshot</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkMenuItem" id="menuitem24">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Create Configuration</property>
                         <signal name="activate" handler="on_create_config" swapped="no"/>
                       </object>
@@ -139,13 +139,13 @@ for filesystem snapshot management</property>
             </child>
             <child>
               <object class="GtkToolButton" id="toolbutton6">
-                <property name="related_action">open-mountpoint</property>
+                <property name="related-action">open-mountpoint</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Open snapshot mountpoint</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Open snapshot mountpoint</property>
                 <property name="label" translatable="yes">Open</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-open</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-open</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -154,12 +154,12 @@ for filesystem snapshot management</property>
             </child>
             <child>
               <object class="GtkToolButton" id="toolbutton2">
-                <property name="related_action">delete-snapshot</property>
+                <property name="related-action">delete-snapshot</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Del</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-remove</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-remove</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -168,12 +168,12 @@ for filesystem snapshot management</property>
             </child>
             <child>
               <object class="GtkToolButton" id="toolbutton8">
-                <property name="related_action">view-changes</property>
+                <property name="related-action">view-changes</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Changes</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-file</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-file</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -190,18 +190,18 @@ for filesystem snapshot management</property>
         <child>
           <object class="GtkPaned" id="paned1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkViewport" id="snapshotsviewport">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="shadow_type">none</property>
+                <property name="can-focus">False</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkStack" id="stack1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="transition_type">slide-left-right</property>
+                    <property name="can-focus">False</property>
+                    <property name="transition-type">slide-left-right</property>
                     <signal name="set-focus-child" handler="on_stack_visible_child_changed" swapped="no"/>
                     <child>
                       <placeholder/>
@@ -217,21 +217,21 @@ for filesystem snapshot management</property>
             <child>
               <object class="GtkExpander" id="userdataexpander">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="expanded">True</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="shadow_type">in</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkTreeView" id="userdatatreeview">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_visible">False</property>
-                        <property name="headers_clickable">False</property>
-                        <property name="expander_column">treeviewcolumn6</property>
-                        <property name="search_column">0</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="headers-clickable">False</property>
+                        <property name="expander-column">treeviewcolumn6</property>
+                        <property name="search-column">0</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection" id="treeview-selection1"/>
                         </child>
@@ -266,7 +266,7 @@ for filesystem snapshot management</property>
                 <child type="label">
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Userdata</property>
                   </object>
                 </child>
@@ -286,7 +286,7 @@ for filesystem snapshot management</property>
         <child>
           <object class="GtkStatusbar" id="statusbar">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">2</property>
           </object>
@@ -301,14 +301,29 @@ for filesystem snapshot management</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="title">SnapperGUI</property>
-        <property name="show_close_button">True</property>
+        <property name="show-close-button">True</property>
         <child>
-          <object class="GtkStackSwitcher" id="stackswitcher1">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stack">stack1</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <property name="propagate-natural-width">True</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkStackSwitcher" id="stackswitcher1">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="resize-mode">queue</property>
+                    <property name="stack">stack1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>


### PR DESCRIPTION
allows a sliding top bar so users with multiple disks can actually access all the snapshots when monitor space is filled 
![Screenshot from 2023-11-09 20-26-36](https://github.com/ricardomv/snapper-gui/assets/1857824/6dd88b44-08ee-42f7-91aa-ac630c0551df)
