### PR TITLE
Fix an issue where modifying a snapshot or unknown circumstances caused node.children to be None

### DIFF
--- a/snappergui/changesWindow.py
+++ b/snappergui/changesWindow.py
@@ -62,14 +62,16 @@ class changesWindow(object):
         node = tree
         # Add directories to tree
         for file_name in parts[1:-1]:
-            if not file_name in node.children:
-                node.children[file_name] = changesWindow.TreeNode("", {}, 0, True)
-            node = node.children[file_name]
+            if node.children is not None:
+                if not file_name in node.children:
+                    node.children[file_name] = changesWindow.TreeNode("", {}, 0, True)
+                node = node.children[file_name]
         # Add last part of path to tree
-        if is_dir:
-            node.children[parts[-1]] = changesWindow.TreeNode("", {}, status, True)
-        else:
-            node.children[parts[-1]] = changesWindow.TreeNode(path, None, status, False)
+        if node.children is not None:
+            if is_dir:
+                node.children[parts[-1]] = changesWindow.TreeNode("", {}, status, True)
+            else:
+                node.children[parts[-1]] = changesWindow.TreeNode(path, None, status, False)
 
     def print_tree(self, tree, indent=""):
         for name, child in tree.children.items():

--- a/snappergui/changesWindow.py
+++ b/snappergui/changesWindow.py
@@ -162,7 +162,7 @@ class changesWindow(object):
 
     def get_lines_from_file(self, path):
         try:
-            return open(path, 'U').readlines()
+            return open(path).readlines()
         except IsADirectoryError:
             pass
         except FileNotFoundError:


### PR DESCRIPTION
#62 #59 #58 
node children python TypeError: 'NoneType' object does not support item assignment

Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/snappergui/changesWindow.py", line 145, in on_idle_init_paths_tree
self.add_path_to_tree(str(entry[0]), int(entry[1]), files_tree)
File "/usr/lib/python3/dist-packages/snappergui/changesWindow.py", line 70, in add_path_to_tree
node.children[parts[-1]] = changesWindow.TreeNode(path, None, status, False)
~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: 'NoneType' object does not support item assignment 