### PR TITLE
Update snapper-gui.desktop

### DIFF
--- a/snapper-gui.desktop
+++ b/snapper-gui.desktop
@@ -7,3 +7,5 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Utilities;System;
+X-KDE-SubstituteUID=true
+X-KDE-Username=root


### PR DESCRIPTION
We should really have this run as root. here is how we do it in KDE